### PR TITLE
driver: allow send hci_packet for drivers

### DIFF
--- a/docs/mkdocs/src/drivers/index.md
+++ b/docs/mkdocs/src/drivers/index.md
@@ -10,7 +10,7 @@ used with particular HCI controller.
 When the transport for an HCI controller is instantiated from a transport name,
 a driver may also be forced by specifying ``driver=<driver-name>`` in the optional
 metadata portion of the transport name. For example,
-``usb:[driver=-rtk]0`` indicates that the ``rtk`` driver should be used with the
+``usb:[driver=rtk]0`` indicates that the ``rtk`` driver should be used with the
 first USB device, even if a normal probe would not have selected it based on the
 USB vendor ID and product ID.
 


### PR DESCRIPTION
Allow to send hci_packet for drivers that don't support the
HCI_RESET before the firmware update

Correct a typo in the doc
