### PR TITLE
avatar: reduce number of shards

### DIFF
--- a/.github/workflows/python-avatar.yml
+++ b/.github/workflows/python-avatar.yml
@@ -40,4 +40,11 @@ jobs:
           avatar --list | grep -Ev '^=' > test-names.txt
           timeout 5m avatar --test-beds bumble.bumbles --tests $(split test-names.txt -n l/${{ matrix.shard }})
       - name: Rootcanal Logs
+        if: always()
         run: cat rootcanal.log
+      - name: Upload Mobly logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mobly-logs
+          path: /tmp/logs/mobly/bumble.bumbles/

--- a/.github/workflows/python-avatar.yml
+++ b/.github/workflows/python-avatar.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test
         run: |
           avatar --list | grep -Ev '^=' > test-names.txt
-          timeout 5m avatar --test-beds bumble.bumbles --tests $(split test-names.txt -n l/${{ matrix.shard }})
+          timeout 10m avatar --test-beds bumble.bumbles --tests $(split test-names.txt -n l/${{ matrix.shard }})
       - name: Rootcanal Logs
         if: always()
         run: cat rootcanal.log

--- a/.github/workflows/python-avatar.yml
+++ b/.github/workflows/python-avatar.yml
@@ -14,14 +14,10 @@ jobs:
     name: Avatar [${{ matrix.shard }}]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shard: [
-           1/24,  2/24,  3/24,  4/24,
-           5/24,  6/24,  7/24,  8/24,
-           9/24, 10/24, 11/24, 12/24,
-          13/24, 14/24, 15/24, 16/24,
-          17/24, 18/24, 19/24, 20/24,
-          21/24, 22/24, 23/24, 24/24,
+           1/4,  2/4,  3/4,  4/4,
         ]
     steps:
       - uses: actions/checkout@v3

--- a/bumble/hci.py
+++ b/bumble/hci.py
@@ -3440,11 +3440,11 @@ class HCI_Read_Local_Supported_Codecs_V2_Command(HCI_Command):
     See Bluetooth spec @ 7.4.8 Read Local Supported Codecs Command
     '''
 
-    class Transport(OpenIntEnum):
-        BR_EDR_ACL = 0x00
-        BR_EDR_SCO = 0x01
-        LE_CIS = 0x02
-        LE_BIS = 0x03
+    class Transport(enum.IntFlag):
+        BR_EDR_ACL = 1 << 0
+        BR_EDR_SCO = 1 << 1
+        LE_CIS = 1 << 2
+        LE_BIS = 1 << 3
 
 
 # -----------------------------------------------------------------------------

--- a/docs/mkdocs/src/examples/index.md
+++ b/docs/mkdocs/src/examples/index.md
@@ -42,6 +42,9 @@ An app that connected to a device (BLE) and encrypts the connection.
 ## `run_controller.py`
 Creates two linked controllers, attaches one to a transport, and the other to a local host with a GATT server application. This can be used, for example, to attach a virtual controller to a native stack, like BlueZ on Linux, and use the native tools, like `bluetoothctl`, to scan and connect to the GATT server included in the example.
 
+## `run_csis_servers.py`
+Runs CSIS servers on two devices to form a Coordinated Set. **Note**: If using the example config file (e.g. `device1.json`), the `address` needs to be removed, so that the devices are given different random addresses.   
+
 ## `run_gatt_client_and_server.py`
 Runs a local GATT server and GATT client, connected to each other. The GATT client discovers and logs all the services and characteristics exposed by the GATT server
 

--- a/docs/mkdocs/src/examples/index.md
+++ b/docs/mkdocs/src/examples/index.md
@@ -1,7 +1,7 @@
 EXAMPLES
 ========
 
-The project includes a few simple example applications the illustrate some of the ways the library APIs can be used.
+The project includes a few simple example applications to illustrate some of the ways the library APIs can be used.
 These examples include:
 
 ## `battery_service.py`

--- a/examples/run_csis_servers.py
+++ b/examples/run_csis_servers.py
@@ -38,13 +38,10 @@ from bumble.transport import open_transport_or_link
 async def main() -> None:
     if len(sys.argv) < 3:
         print(
-            'Usage: run_cig_setup.py <config-file>'
+            'Usage: run_csis_servers.py <config-file> '
             '<transport-spec-for-device-1> <transport-spec-for-device-2>'
         )
-        print(
-            'example: run_cig_setup.py device1.json'
-            'tcp-client:127.0.0.1:6402 tcp-client:127.0.0.1:6402'
-        )
+        print('example: run_csis_servers.py device1.json ' 'hci-socket:0 hci-socket:1')
         return
 
     print('<<< connecting to HCI...')

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ development =
     types-protobuf >= 4.21.0
     wasmtime == 20.0.0
 avatar =
-    pandora-avatar == 0.0.9
+    pandora-avatar == 0.0.10
     rootcanal == 1.10.0 ; python_version>='3.10'
 pandora =
     bt-test-interfaces >= 0.0.6


### PR DESCRIPTION
Having too many shards extends the total testing time. 4 shards is a
good compromise.

Also, run all the shards and does not skip when one shard is failing
